### PR TITLE
Kv 支持 getKv 和 getListKv，JsonUtil 支持反序列化为 list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.xkcoding.json</groupId>
   <artifactId>simple-json</artifactId>
-  <version>0.0.3</version>
+  <version>0.0.4</version>
 
   <name>${project.artifactId}</name>
   <url>https://github.com/xkcoding/simple-json</url>

--- a/src/main/java/com/xkcoding/json/JsonUtil.java
+++ b/src/main/java/com/xkcoding/json/JsonUtil.java
@@ -12,6 +12,8 @@ import com.xkcoding.json.util.ClassUtil;
 import com.xkcoding.json.util.Kv;
 import lombok.experimental.UtilityClass;
 
+import java.util.List;
+
 /**
  * <p>
  * Json工具类
@@ -99,6 +101,18 @@ public class JsonUtil {
 	public <T> T toBean(String jsonStr, Class<T> clazz) {
 		checkJsonAdapterNotNull(jsonAdapter);
 		return jsonAdapter.deserialize(jsonStr, clazz);
+	}
+
+	/**
+	 * 反序列化为集合
+	 *
+	 * @param jsonStr json 字符串
+	 * @param clazz   对象类型
+	 * @return 对象
+	 */
+	public <T> List<T> toList(String jsonStr, Class<T> clazz) {
+		checkJsonAdapterNotNull(jsonAdapter);
+		return jsonAdapter.deserializeList(jsonStr, clazz);
 	}
 
 	/**

--- a/src/main/java/com/xkcoding/json/support/JsonAdapter.java
+++ b/src/main/java/com/xkcoding/json/support/JsonAdapter.java
@@ -2,6 +2,8 @@ package com.xkcoding.json.support;
 
 import com.xkcoding.json.exception.SimpleJsonException;
 
+import java.util.List;
+
 /**
  * <p>
  * 序列化反序列化操作
@@ -30,4 +32,15 @@ public interface JsonAdapter {
 	 * @throws SimpleJsonException 自定义异常
 	 */
 	<T> T deserialize(String jsonStr, Class<T> clazz) throws SimpleJsonException;
+
+	/**
+	 * 反序列化为集合
+	 *
+	 * @param <T>     类泛型
+	 * @param jsonStr json 字符串
+	 * @param clazz   对象类型
+	 * @return 对象集合
+	 * @throws SimpleJsonException 自定义异常
+	 */
+	<T> List<T> deserializeList(String jsonStr, Class<T> clazz) throws SimpleJsonException;
 }

--- a/src/main/java/com/xkcoding/json/support/fastjson/FastJsonJsonAdapter.java
+++ b/src/main/java/com/xkcoding/json/support/fastjson/FastJsonJsonAdapter.java
@@ -1,11 +1,14 @@
 package com.xkcoding.json.support.fastjson;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.xkcoding.json.config.JsonConfig;
 import com.xkcoding.json.exception.SimpleJsonException;
 import com.xkcoding.json.support.AbstractJsonAdapter;
 import com.xkcoding.json.util.StringUtil;
+
+import java.util.List;
 
 /**
  * <p>
@@ -52,5 +55,19 @@ public class FastJsonJsonAdapter extends AbstractJsonAdapter {
 	@Override
 	public <T> T deserialize(String jsonStr, Class<T> clazz) throws SimpleJsonException {
 		return JSON.parseObject(jsonStr, clazz);
+	}
+
+	/**
+	 * 反序列化为集合
+	 *
+	 * @param <T>     类泛型
+	 * @param jsonStr json 字符串
+	 * @param clazz   对象类型
+	 * @return 对象集合
+	 * @throws SimpleJsonException 自定义异常
+	 */
+	@Override
+	public <T> List<T> deserializeList(String jsonStr, Class<T> clazz) throws SimpleJsonException {
+		return JSONArray.parseArray(jsonStr, clazz);
 	}
 }

--- a/src/main/java/com/xkcoding/json/support/gson/GsonJsonAdapter.java
+++ b/src/main/java/com/xkcoding/json/support/gson/GsonJsonAdapter.java
@@ -1,6 +1,7 @@
 package com.xkcoding.json.support.gson;
 
 import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
 import com.xkcoding.json.config.JsonConfig;
 import com.xkcoding.json.exception.SimpleJsonException;
 import com.xkcoding.json.support.AbstractJsonAdapter;
@@ -8,7 +9,9 @@ import com.xkcoding.json.util.StringUtil;
 
 import java.lang.reflect.Type;
 import java.text.DateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * <p>
@@ -70,6 +73,21 @@ public class GsonJsonAdapter extends AbstractJsonAdapter {
 	@Override
 	public <T> T deserialize(String jsonStr, Class<T> clazz) throws SimpleJsonException {
 		return gson.fromJson(jsonStr, clazz);
+	}
+
+	/**
+	 * 反序列化为集合
+	 *
+	 * @param <T>     类泛型
+	 * @param jsonStr json 字符串
+	 * @param clazz   对象类型
+	 * @return 对象集合
+	 * @throws SimpleJsonException 自定义异常
+	 */
+	@Override
+	public <T> List<T> deserializeList(String jsonStr, Class<T> clazz) throws SimpleJsonException {
+		Type listType = new TypeToken<ArrayList<T>>(){}.getType();
+		return new Gson().fromJson(jsonStr, listType);
 	}
 
 	private static class GsonDateSerializer implements JsonSerializer<Date> {

--- a/src/main/java/com/xkcoding/json/support/hutool/HutoolJsonJsonAdapter.java
+++ b/src/main/java/com/xkcoding/json/support/hutool/HutoolJsonJsonAdapter.java
@@ -7,6 +7,8 @@ import com.xkcoding.json.exception.SimpleJsonException;
 import com.xkcoding.json.support.AbstractJsonAdapter;
 import com.xkcoding.json.util.StringUtil;
 
+import java.util.List;
+
 /**
  * <p>
  * Hutool JSON 序列化实现，时间格式化可以通过 {@link JsonConfig} 设置，默认为时间戳类型
@@ -65,4 +67,18 @@ public class HutoolJsonJsonAdapter extends AbstractJsonAdapter {
 	public <T> T deserialize(String jsonStr, Class<T> clazz) throws SimpleJsonException {
 		return JSONUtil.parse(jsonStr, hutoolJsonConfig).toBean(clazz);
 	}
+
+	/**
+	 * 反序列化为集合
+	 *
+	 * @param <T>     类泛型
+	 * @param jsonStr json 字符串
+	 * @param clazz   对象类型
+	 * @return 对象集合
+	 * @throws SimpleJsonException 自定义异常
+	 */
+    @Override
+    public <T> List<T> deserializeList(String jsonStr, Class<T> clazz) throws SimpleJsonException {
+        return JSONUtil.toList(jsonStr, clazz);
+    }
 }

--- a/src/main/java/com/xkcoding/json/support/jackson/JacksonJsonAdapter.java
+++ b/src/main/java/com/xkcoding/json/support/jackson/JacksonJsonAdapter.java
@@ -1,6 +1,7 @@
 package com.xkcoding.json.support.jackson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xkcoding.json.config.JsonConfig;
 import com.xkcoding.json.exception.SimpleJsonException;
@@ -8,6 +9,7 @@ import com.xkcoding.json.support.AbstractJsonAdapter;
 import com.xkcoding.json.util.StringUtil;
 
 import java.text.SimpleDateFormat;
+import java.util.List;
 
 /**
  * <p>
@@ -70,6 +72,25 @@ public class JacksonJsonAdapter extends AbstractJsonAdapter {
 	public <T> T deserialize(String jsonStr, Class<T> clazz) throws SimpleJsonException {
 		try {
 			return objectMapper.readValue(jsonStr, clazz);
+		} catch (JsonProcessingException e) {
+			throw new SimpleJsonException(e);
+		}
+	}
+
+	/**
+	 * 反序列化为集合
+	 *
+	 * @param <T>     类泛型
+	 * @param jsonStr json 字符串
+	 * @param clazz   对象类型
+	 * @return 对象集合
+	 * @throws SimpleJsonException 自定义异常
+	 */
+    @Override
+    public <T> List<T> deserializeList(String jsonStr, Class<T> clazz) throws SimpleJsonException {
+		JavaType javaType = objectMapper.getTypeFactory().constructCollectionType(List.class, clazz);
+		try {
+			return objectMapper.readValue(jsonStr, javaType);
 		} catch (JsonProcessingException e) {
 			throw new SimpleJsonException(e);
 		}

--- a/src/main/java/com/xkcoding/json/util/Kv.java
+++ b/src/main/java/com/xkcoding/json/util/Kv.java
@@ -1,7 +1,11 @@
 package com.xkcoding.json.util;
 
+import com.xkcoding.json.exception.SimpleJsonException;
+
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * 继承自 HashMap，提供一些基础的类型转换，方便使用
@@ -84,5 +88,37 @@ public class Kv extends HashMap<String, Object> {
 	public double getDoubleValue(String key) {
 		Double value = getDouble(key);
 		return null == value ? 0 : value;
+	}
+
+	public Kv getKv(String key) {
+		Object value = super.get(key);
+		if (null == value) {
+			return null;
+		}
+		if (value instanceof Map) {
+			Kv kv = new Kv();
+			kv.putAll((Map) value);
+			return kv;
+		}
+		throw new SimpleJsonException(value.getClass().getName() + " cannot be cast to com.xkcoding.json.util.Kv");
+	}
+
+	public List<Kv> getListKv(String key) {
+		List<Object> values = getArrayList(key);
+		if (null == values) {
+			return null;
+		}
+		List<Kv> result = new ArrayList<>();
+		Kv item = null;
+		for (Object o : values) {
+			if (o instanceof Map) {
+				item = new Kv();
+				item.putAll((Map) o);
+				result.add(item);
+				continue;
+			}
+			throw new SimpleJsonException(o.getClass().getName() + " cannot be cast to com.xkcoding.json.util.Kv");
+		}
+		return result;
 	}
 }

--- a/src/test/java/com/xkcoding/json/JsonUtilTest.java
+++ b/src/test/java/com/xkcoding/json/JsonUtilTest.java
@@ -14,9 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.Serializable;
-import java.util.Date;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * <p>
@@ -119,6 +117,82 @@ public class JsonUtilTest {
 		System.out.println(kv.getString("birth"));
 	}
 
+	@Test
+	public void testSerializeToKv() {
+		Group serializeGroupTest = new Group(UUID.randomUUID().toString(), "序列化测试", serializeTest, Collections.singletonList(serializeTest));
+
+		String jsonString = JsonUtil.toJsonString(serializeGroupTest);
+		System.out.println(jsonString);
+
+		Kv kv = JsonUtil.parseKv(jsonString);
+		System.out.println(kv);
+		System.out.println(kv.getKv("user"));
+		System.out.println(kv.getListKv("users"));
+		System.out.println(kv.getString("uuid"));
+		System.out.println(kv.getString("name"));
+	}
+
+	@Test
+	public void testDeserializeToBean() {
+		String jsonString = "{\"uuid\":\"6f173244-26f7-4fb1-aed3-fec4ebf635a4\",\"name\":\"序列化测试\",\"user\":{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328},\"users\":[{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328}]}";
+		System.out.println(jsonString);
+
+		Group group = JsonUtil.toBean(jsonString, Group.class);
+		System.out.println(group);
+		System.out.println(group.getUser());
+		System.out.println(group.getUsers());
+		System.out.println(group.getUuid());
+		System.out.println(group.getName());
+	}
+
+	@Test
+	public void testFastJsonDeserializeToListBean() {
+		JsonUtil.setJsonAdapter(new FastJsonJsonAdapter());
+		JsonUtil.setConfig(jsonConfig);
+
+		String jsonString = "[{\"uuid\":\"6f173244-26f7-4fb1-aed3-fec4ebf635a4\",\"name\":\"序列化测试\",\"user\":{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328},\"users\":[{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328}]}]";
+		System.out.println(jsonString);
+
+		List<Group> group = JsonUtil.toList(jsonString, Group.class);
+		System.out.println(group);
+	}
+
+	@Test
+	public void testGsonDeserializeToListBean() {
+		JsonUtil.setJsonAdapter(new GsonJsonAdapter());
+		JsonUtil.setConfig(jsonConfig);
+
+		String jsonString = "[{\"uuid\":\"6f173244-26f7-4fb1-aed3-fec4ebf635a4\",\"name\":\"序列化测试\",\"user\":{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328},\"users\":[{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328}]}]";
+		System.out.println(jsonString);
+
+		List<Group> group = JsonUtil.toList(jsonString, Group.class);
+		System.out.println(group);
+	}
+
+	@Test
+	public void testHutoolDeserializeToListBean() {
+		JsonUtil.setJsonAdapter(new HutoolJsonJsonAdapter());
+		JsonUtil.setConfig(jsonConfig);
+
+		String jsonString = "[{\"uuid\":\"6f173244-26f7-4fb1-aed3-fec4ebf635a4\",\"name\":\"序列化测试\",\"user\":{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328},\"users\":[{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328}]}]";
+		System.out.println(jsonString);
+
+		List<Group> group = JsonUtil.toList(jsonString, Group.class);
+		System.out.println(group);
+	}
+
+	@Test
+	public void testJacksonDeserializeToListBean() {
+		JsonUtil.setJsonAdapter(new JacksonJsonAdapter());
+		JsonUtil.setConfig(jsonConfig);
+
+		String jsonString = "[{\"uuid\":\"6f173244-26f7-4fb1-aed3-fec4ebf635a4\",\"name\":\"序列化测试\",\"user\":{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328},\"users\":[{\"uuid\":\"17260395-b043-4cc0-8cfb-b81e525ff08c\",\"name\":\"序列化测试\",\"age\":20,\"birth\":1677422867328}]}]";
+		System.out.println(jsonString);
+
+		List<Group> group = JsonUtil.toList(jsonString, Group.class);
+		System.out.println(group);
+	}
+
 	@Data
 	@NoArgsConstructor
 	@AllArgsConstructor
@@ -127,5 +201,15 @@ public class JsonUtilTest {
 		private String name;
 		private Integer age;
 		private Date birth;
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	static class Group implements Serializable {
+		private String uuid;
+		private String name;
+		private User user;
+		private List<User> users;
 	}
 }


### PR DESCRIPTION
1. Kv 支持 getKv 和 getListKv

```json
{
	"key": {
		"str": "",
		"obj": {
			"str": ""
		}
	},
	"list": [{
		"key": {
			"str": ""
		}
	}]
}
```
针对 这种格式的 json，最多只能反序列化到 Kv，Kv 对象如果再想链式往下 get 就得一层一层转，比较麻烦。如果想在 kv 里获取 list 对象，并且对象可以直接转为 kv，也比较麻烦，所以对这两种方法进行支持；

![image](https://user-images.githubusercontent.com/12689082/221419948-80e3408c-b7f8-4e36-a3e8-25028f6e91b4.png)

ps: 看上面，给我转麻了

2. JsonUtil 支持反序列化为 list

![image](https://user-images.githubusercontent.com/12689082/221419983-470f64ec-199d-448c-a31c-bb3237b8ae46.png)

ps: 看上面，给我转麻了
